### PR TITLE
fix(options): add proper path-checking for filter in windows

### DIFF
--- a/src/optionsUtils.js
+++ b/src/optionsUtils.js
@@ -19,7 +19,7 @@ const optionsSchema = Joi.object().keys({
 });
 
 const defaultOptions = {
-  filter: /(^.*\/node_modules\/((?:@[^/]+\/)?(?:[^/]+)))/,
+  filter: /(^.*(\/|\\)node_modules(\/|\\)((?:@[^(\/|\\)]+\/)?(?:[^(\/|\\)]+)))/,
   allow: "(Apache-2.0 OR BSD-2-Clause OR BSD-3-Clause OR MIT)",
   ignore: [],
   override: {},


### PR DESCRIPTION
Regex didn't include backslashes for windows environments so the plugin never included licenses.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/license-checker-webpack-plugin/4)
<!-- Reviewable:end -->
