### PR TITLE
Add support for old package.json license format

### DIFF
--- a/src/licenseUtils.js
+++ b/src/licenseUtils.js
@@ -18,6 +18,15 @@ const getLicenseContents = dependencyPath => {
   return licensePath && wrap(readFileSync(licensePath).toString(), licenseWrap);
 };
 
+const getLicenseName = package => {
+    if (package.licenses) {
+        const licenseName = package.licenses.map(license => license.type).join(" OR ");
+        return package.licenses.length > 1 ? `(${licenseName})` : licenseName;
+    }
+
+    return package.license;
+}
+
 const getLicenseInformationForDependency = dependencyPath => {
   const package = require(`${dependencyPath}/package.json`);
   return {
@@ -25,7 +34,7 @@ const getLicenseInformationForDependency = dependencyPath => {
     version: package.version,
     author: (package.author && package.author.name) || package.author,
     repository: (package.repository && package.repository.url) || package.repository,
-    licenseName: package.license,
+    licenseName: getLicenseName(package),
     licenseText: getLicenseContents(dependencyPath)
   };
 };


### PR DESCRIPTION
I am not sure we should support this here, because it's a deprecated format as we can see here: https://docs.npmjs.com/files/package.json#license so libraries should just adapt to it.

However, since there is no harm on having it, it could be nice to support that old format.

Reference: https://github.com/CodeSeven/toastr/pull/604