### PR TITLE
fix: broken due to breaking changes of joi

### DIFF
--- a/src/optionsUtils.js
+++ b/src/optionsUtils.js
@@ -4,7 +4,7 @@ const defaultOutputWriter = require("./defaultOutputWriter");
 
 const optionsSchema = Joi.object().keys({
   filter: Joi.object()
-    .type(RegExp)
+    .instance(RegExp)
     .required(),
   allow: Joi.string().required(),
   ignore: Joi.array()
@@ -31,7 +31,7 @@ const defaultOptions = {
 const getOptions = options => {
   const finalOptions = Object.assign({}, defaultOptions, options);
 
-  const result = Joi.validate(finalOptions, optionsSchema);
+  const result = optionsSchema.validate(finalOptions);
   if (result.error != null) {
     throw result.error;
   }


### PR DESCRIPTION
v0.1.1 is broken due to update of joi (4825b2fc54c38a53ed0d723831e035e4cf471a85 @hapi/joi 15.1.1 -> ^16.1.2).

There are many changes in joi 16.0.0 (https://github.com/hapijs/joi/issues/2037), including:
```
Rename object.type() to object.instance() and any.schemaType to any.type (#1942, #1943)
```
```
Remove Joi.validate() and Joi.describe() (call direct on schema instead) (#1941)
```

As a result, `src/optionsUtils.js` causes errors now:
```
TypeError: Joi.object(...).type is not a function
    at Object.<anonymous> (/path/to/node_modules/license-checker-webpack-plugin/src/optionsUtils.js:7:6)
```
```
TypeError: Joi.validate is not a function
    at getOptions (/path/to/node_modules/license-checker-webpack-plugin/src/optionsUtils.js:34:22)
```