### PR TITLE
Prevent license glob from capturing directories

### DIFF
--- a/src/licenseUtils.js
+++ b/src/licenseUtils.js
@@ -13,7 +13,7 @@ const licenseGlob = "LICENSE*";
 const licenseWrap = 80;
 
 const getLicenseContents = dependencyPath => {
-  const [licenseFilename] = glob.sync(licenseGlob, { cwd: dependencyPath, nocase: true });
+  const [licenseFilename] = glob.sync(licenseGlob, { cwd: dependencyPath, nocase: true, nodir: true });
   const licensePath = licenseFilename && resolve(dependencyPath, licenseFilename);
   return licensePath && wrap(readFileSync(licensePath).toString(), licenseWrap);
 };


### PR DESCRIPTION
If a `dependencyPath` contains a directory that matches the `licenseGlob` the `getLicenseContents` method attempts to read the file content of the directory. This fails with the following error:
```
Error: EISDIR: illegal operation on a directory, read
    at Object.readSync (fs.js:524:3)
    at tryReadSync (fs.js:349:20)
    at readFileSync (fs.js:386:19)
    at getLicenseContents (C:\...\node_modules\license-checker-webpack-plugin\src\licenseUtils.js:19:30)
```

The proposed change excludes directories from the glob.