### PR TITLE
Switch options validation to superstruct

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -270,46 +270,6 @@
         "minimist": "^1.2.0"
       }
     },
-    "@hapi/address": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
-      "integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ=="
-    },
-    "@hapi/formula": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-1.2.0.tgz",
-      "integrity": "sha512-UFbtbGPjstz0eWHb+ga/GM3Z9EzqKXFWIbSOFURU0A/Gku0Bky4bCk9/h//K2Xr3IrCfjFNhMm4jyZ5dbCewGA=="
-    },
-    "@hapi/hoek": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
-      "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
-    },
-    "@hapi/joi": {
-      "version": "16.1.8",
-      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
-      "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
-      "requires": {
-        "@hapi/address": "^2.1.2",
-        "@hapi/formula": "^1.2.0",
-        "@hapi/hoek": "^8.2.4",
-        "@hapi/pinpoint": "^1.0.2",
-        "@hapi/topo": "^3.1.3"
-      }
-    },
-    "@hapi/pinpoint": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-1.0.2.tgz",
-      "integrity": "sha512-dtXC/WkZBfC5vxscazuiJ6iq4j9oNx1SHknmIr8hofarpKUZKmlUVYVIhNVzIEgK5Wrc4GMHL5lZtt1uS2flmQ=="
-    },
-    "@hapi/topo": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
-      "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
-      "requires": {
-        "@hapi/hoek": "^8.3.0"
-      }
-    },
     "@jest/console": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
@@ -6441,6 +6401,11 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
+    },
+    "superstruct": {
+      "version": "0.10.12",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.10.12.tgz",
+      "integrity": "sha512-FiNhfegyytDI0QxrrEoeGknFM28SnoHqCBpkWewUm8jRNj74NVxLpiiePvkOo41Ze/aKMSHa/twWjNF81mKaQQ=="
     },
     "supports-color": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -24,13 +24,13 @@
     "webpack": "^4.0.0"
   },
   "dependencies": {
-    "@hapi/joi": "^16.1.7",
     "glob": "^7.1.6",
     "lodash.template": "^4.5.0",
     "minimatch": "^3.0.4",
     "semver": "^6.3.0",
     "spdx-expression-validate": "^2.0.0",
     "spdx-satisfies": "^5.0.0",
+    "superstruct": "^0.10.12",
     "webpack-sources": "^1.4.3",
     "wrap-ansi": "^6.1.0"
   },

--- a/src/optionsUtils.js
+++ b/src/optionsUtils.js
@@ -1,21 +1,34 @@
-const Joi = require("@hapi/joi");
+const {
+  array,
+  assert,
+  boolean,
+  instance,
+  object,
+  partial,
+  record,
+  string,
+  union
+} = require("superstruct");
 
 const defaultOutputWriter = require("./defaultOutputWriter");
 
-const optionsSchema = Joi.object().keys({
-  filter: Joi.object()
-    .instance(RegExp)
-    .required(),
-  allow: Joi.string().required(),
-  ignore: Joi.array()
-    .items(Joi.string())
-    .required(),
-  override: Joi.object().required(),
-  emitError: Joi.boolean().required(),
-  outputWriter: Joi.alternatives()
-    .try(Joi.string(), Joi.func())
-    .required(),
-  outputFilename: Joi.string().required()
+const optionsSchema = object({
+  filter: instance(RegExp),
+  allow: string(),
+  ignore: array(string()),
+  override: record(
+    string(),
+    partial({
+      name: string(),
+      version: string(),
+      repository: string(),
+      licenseName: string(),
+      licenseText: string()
+    })
+  ),
+  emitError: boolean(),
+  outputWriter: union([string(), instance(Function)]),
+  outputFilename: string()
 });
 
 const defaultOptions = {
@@ -31,10 +44,7 @@ const defaultOptions = {
 const getOptions = options => {
   const finalOptions = Object.assign({}, defaultOptions, options);
 
-  const result = optionsSchema.validate(finalOptions);
-  if (result.error != null) {
-    throw result.error;
-  }
+  assert(finalOptions, optionsSchema);
 
   return finalOptions;
 };

--- a/src/optionsUtils.spec.js
+++ b/src/optionsUtils.spec.js
@@ -1,0 +1,49 @@
+const { getOptions } = require("./optionsUtils");
+
+const defaults = {
+  allow: "(Apache-2.0 OR BSD-2-Clause OR BSD-3-Clause OR MIT)",
+  emitError: false,
+  filter: expect.any(RegExp),
+  ignore: [],
+  outputFilename: "ThirdPartyNotice.txt",
+  outputWriter: expect.any(String),
+  override: {}
+};
+
+describe("getOptions", () => {
+  it("should provide defaults when undefined", () => {
+    expect(getOptions()).toStrictEqual(defaults);
+  });
+
+  it("should provide defaults when empty", () => {
+    expect(getOptions({})).toStrictEqual(defaults);
+  });
+
+  it("should throw for unknown property", () => {
+    expect(() => getOptions({ bad: 1 })).toThrowErrorMatchingInlineSnapshot(
+      `"Expected a value of type \`never\` for \`bad\` but received \`1\`."`
+    );
+  });
+
+  it("should accept 'ignore' property", () => {
+    const options = { ignore: ["assignment@^2.0.0"] };
+    expect(getOptions(options)).toStrictEqual(Object.assign({}, defaults, options));
+  });
+
+  it("should accept 'outputWriter' property as function", () => {
+    const options = { outputWriter: () => "some output" };
+    expect(getOptions(options)).toStrictEqual(Object.assign({}, defaults, options));
+  });
+
+  it("should accept 'override' property", () => {
+    const options = { override: { "assignment@^2.0.0": { licenseName: "MIT" } } };
+    expect(getOptions(options)).toStrictEqual(Object.assign({}, defaults, options));
+  });
+
+  it("should throw for unknown 'override' value property", () => {
+    const options = { override: { "assignment@^2.0.0": { licenceName: "MIT" } } };
+    expect(() => getOptions(options)).toThrowErrorMatchingInlineSnapshot(
+      `"Expected a value of type \`never\` for \`override.assignment@^2.0.0.licenceName\` but received \`\\"MIT\\"\`."`
+    );
+  });
+});


### PR DESCRIPTION
The joi validation package is deprecated/moving repository.

Going off shellscape/webpack-plugin-serve#188 superstruct seems a solid replacement. Basic validation works fine, and can be customised as needed.

Add some tests for option validation.