### PR TITLE
Update licenseGlob to allow checking for LICENCE files.

### DIFF
--- a/src/__mocks__/module-with-licence/LICENCE
+++ b/src/__mocks__/module-with-licence/LICENCE
@@ -1,0 +1,1 @@
+LICENCE TEXT

--- a/src/__mocks__/module-with-license/LICENSE
+++ b/src/__mocks__/module-with-license/LICENSE
@@ -1,0 +1,1 @@
+LICENSE TEXT

--- a/src/licenseUtils.js
+++ b/src/licenseUtils.js
@@ -9,7 +9,7 @@ const isSatisfiedLicense = require("spdx-satisfies");
 const wrap = require("wrap-ansi");
 const LicenseError = require("./LicenseError");
 
-const licenseGlob = "LICENSE*";
+const licenseGlob = "LICEN@(C|S)E*";
 const licenseWrap = 80;
 
 const getLicenseContents = dependencyPath => {
@@ -131,6 +131,7 @@ const writeLicenseInformation = (outputWriter, dependencies) => {
 
 module.exports = {
   getLicenseName,
+  getLicenseContents,
   getLicenseInformationForCompilation,
   getLicenseViolations,
   getSortedLicenseInformation,

--- a/src/licenseUtils.spec.js
+++ b/src/licenseUtils.spec.js
@@ -1,4 +1,4 @@
-const { getLicenseName } = require("./licenseUtils");
+const { getLicenseName, getLicenseContents } = require("./licenseUtils");
 
 describe("getLicenseName", () => {
   let pkg;
@@ -58,6 +58,33 @@ describe("getLicenseName", () => {
 
     it("should return empty string", () => {
       expect(licenseName).toBe("");
+    });
+  });
+});
+
+describe("getLicenseContents", () => {
+  let licenseContent;
+  let depPath;
+
+  describe("with licen(s)e file", () => {
+    beforeEach(() => {
+      depPath = process.cwd() + "/src/__mocks__/module-with-license/";
+      licenseContent = getLicenseContents(depPath);
+    });
+
+    it("should return text content", () => {
+      expect(licenseContent).not.toBe(undefined);
+    });
+  });
+
+  describe("with licen(c)e file", () => {
+    beforeEach(() => {
+      depPath = process.cwd() + "/src/__mocks__/module-with-licence/";
+      licenseContent = getLicenseContents(depPath);
+    });
+
+    it("should return text content", () => {
+      expect(licenseContent).not.toBe(undefined);
     });
   });
 });


### PR DESCRIPTION
Some packages in our project use an alternative spelling for license.