### PR TITLE
Filter scoped modules correctly

### DIFF
--- a/src/optionsUtils.js
+++ b/src/optionsUtils.js
@@ -32,7 +32,7 @@ const optionsSchema = object({
 });
 
 const defaultOptions = {
-  filter: /(^.*[/\\]node_modules[/\\]((?:@[^/\\]+[/\\])?(?:[^/\\]+)))/,
+  filter: /(^.*[/\\]node_modules[/\\]((?:@[^/\\]+[/\\])?(?:[^@/\\][^/\\]*)))/,
   allow: "(Apache-2.0 OR BSD-2-Clause OR BSD-3-Clause OR MIT)",
   ignore: [],
   override: {},

--- a/src/optionsUtils.spec.js
+++ b/src/optionsUtils.spec.js
@@ -47,3 +47,42 @@ describe("getOptions", () => {
     );
   });
 });
+
+describe("defaults behaviour", () => {
+  const { filter } = getOptions();
+
+  test.each([
+    // Modules are things under node_modules
+    ["/base/node_modules/a-proj/dist/index.js", ["/base/node_modules/a-proj", "a-proj"]],
+    ["/base/node_modules/a-proj/dist", ["/base/node_modules/a-proj", "a-proj"]],
+    ["/base/node_modules/a-proj", ["/base/node_modules/a-proj", "a-proj"]],
+    ["/base/node_modules", null],
+    ["/base", null],
+    ["/", null],
+    // Scoped names have two parts
+    ["/base/node_modules/@babel/runtime/", ["/base/node_modules/@babel/runtime", "@babel/runtime"]],
+    ["/base/node_modules/@babel", null],
+    // Modules can be nested and deepest is retrieved
+    [
+      "/base/node_modules/a-proj/node_modules/b-proj/index.js",
+      ["/base/node_modules/a-proj/node_modules/b-proj", "b-proj"]
+    ],
+    [
+      "/base/node_modules/@a/proj/node_modules/b-proj/index.js",
+      ["/base/node_modules/@a/proj/node_modules/b-proj", "b-proj"]
+    ],
+    [
+      "/base/node_modules/@a/proj/node_modules/@b/proj/src/index.mjs",
+      ["/base/node_modules/@a/proj/node_modules/@b/proj", "@b/proj"]
+    ],
+    [
+      "/base/node_modules/a-proj/node_modules/@b/proj/src/index.mjs",
+      ["/base/node_modules/a-proj/node_modules/@b/proj", "@b/proj"]
+    ],
+    // Backslashes are allowed as separators
+    ["C:\\No\\node_modules\\a-proj\\dist\\index.js", ["C:\\No\\node_modules\\a-proj", "a-proj"]]
+  ])("filter %#", (path, expected) => {
+    const result = filter.exec(path);
+    expect(result ? result.slice(1) : result).toEqual(expected);
+  });
+});


### PR DESCRIPTION
Fixes microsoft/license-checker-webpack-plugin#25

A valid node module name is either `\w+` or `@\w+/\w+` never `@\w+`.

This is enough of a hairy internal implementation detail that filter should probably not be exposed even as an (undocumented) option. But leaving alone for now as changing the pattern has been a useful workaround.

There are some other implications from the webpack 5 changes to `fileDependencies` and the current code behaviours but those will need a bit more discussion to address I think.