### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ module.exports = {
 | `override`       | `object`               | `{}`                                                       | Object of dependencies to override, in the format `{"<dependency name>@<version range>": { ... }}`. For example, `{"assignment@^2.0.0": { licenseName: "MIT" }}`. |
 | `emitError`      | `boolean`              | `false`                                                    | Whether to emit errors instead of warnings.                                                                                                                       |
 | `outputWriter`   | `string` or `function` | See [`defaultOutputWriter`](./src/defaultOutputWriter.js). | Path to a `.ejs` template, or function that will generate the contents of the third-party notices file.                                                           |
-| `outputFilename` | `string`               | `"ThirdPartyNotices.txt"`                                  | Name of the third-party notices file with all licensing information.                                                                                              |
+| `outputFilename` | `string`               | `"ThirdPartyNotice.txt"`                                   | Name of the third-party notices file with all licensing information.                                                                                              |
 
 The data that gets passed to the `outputWriter` function looks like this:
 


### PR DESCRIPTION
The default value in source code: https://github.com/microsoft/license-checker-webpack-plugin/blob/0839ea860b534e142229298efb3bfd91afafa786/src/optionsUtils.js#L41